### PR TITLE
[Wrong Merge Branch] Add residuals plot

### DIFF
--- a/regressors/plots.py
+++ b/regressors/plots.py
@@ -32,9 +32,13 @@ def plot_residuals(clf, X, y, r_type='standardized', figsize=(10, 10)):
         Defaults to 'standardized'.
 
         * 'raw' will return the raw residuals.
-        * 'standardized' will return the standardized residuals, also known as
-          internally studentized residuals.
-        * 'studentized' will return the externally studentized residuals.
+        * 'standardized' will return the Pearson standardized residuals, also
+          known as internally studentized residuals, which is calculated as the
+          residuals divided by the square root of MSE (or the STD of the
+          residuals).
+        * 'studentized' will return the externally studentized residuals, which
+          is calculated as the raw residuals divided by sqrt(LOO-MSE * (1 -
+          leverage_score)).
     figsize : tuple
         A tuple indicating the size of the plot to be created, with format
         (x-axis, y-axis). Defaults to (10, 10).

--- a/regressors/plots.py
+++ b/regressors/plots.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+"""This module contains functions for making plots relevant to regressors."""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+

--- a/regressors/plots.py
+++ b/regressors/plots.py
@@ -13,7 +13,7 @@ from regressors import stats
 from regressors.regressors import supported_linear_models
 
 
-def plot_residuals(clf, X, y, r_type='standardized', figsize=(10, 10)):
+def plot_residuals(clf, X, y, r_type='standardized', figsize=(10, 8)):
     """Plot residuals of a linear model.
 
     Parameters

--- a/regressors/plots.py
+++ b/regressors/plots.py
@@ -1,9 +1,69 @@
 # -*- coding: utf-8 -*-
 
 """This module contains functions for making plots relevant to regressors."""
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 
+import matplotlib.pyplot as plt
+import seaborn.apionly as sns
+from sklearn import linear_model as lm
+
+from regressors import stats
+
+supported_linear_models = (lm.LinearRegression, lm.Lasso, lm.Ridge,
+                           lm.ElasticNet)
+
+
+def plot_residuals(clf, X, y, r_type='standardized', figsize=(10, 10)):
+    """Plot residuals of a linear model.
+
+    Parameters
+    ----------
+    clf : sklearn.linear_model
+        A scikit-learn linear model classifier with a `predict()` method.
+    X : numpy.ndarray
+        Training data used to fit the classifier.
+    y : numpy.ndarray
+        Target training values, of shape = [n_samples].
+    r_type : str
+        Type of residuals to return: ['raw', 'standardized', 'studentized'].
+        Defaults to 'standardized'.
+
+        * 'raw' will return the raw residuals.
+        * 'standardized' will return the standardized residuals, also known as
+          internally studentized residuals.
+        * 'studentized' will return the externally studentized residuals.
+    figsize : tuple
+        A tuple indicating the size of the plot to be created, with format
+        (x-axis, y-axis). Defaults to (10, 10).
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The Figure instance.
+    """
+    # Ensure we only plot residuals using classifiers we have tested
+    assert isinstance(clf, supported_linear_models), (
+        "Classifiers of type {} not currently supported.".format(type(clf))
+    )
+    # With sns, only use their API so you don't change user stuff
+    sns.set_context("talk")  # Increase font size on plot
+    sns.set_style("whitegrid")
+    # Get residuals or standardized residuals
+    resids = stats.residuals(clf, X, y, r_type)
+    predictions = clf.predict(X)
+    # Generate residual plot
+    y_label = {'raw': 'Residuals', 'standardized': 'Standardized Residuals',
+               'studentized': 'Studentized Residuals'}
+    fig = plt.figure('residuals', figsize=figsize)
+    plt.scatter(predictions, resids, s=14, c='gray', alpha=0.7)
+    plt.hlines(y=0, xmin=predictions.min() - 100, xmax=predictions.max() + 100,
+               linestyle='dotted')
+    plt.title("Residuals Plot")
+    plt.xlabel("Predictions")
+    plt.ylabel(y_label[r_type])
+    plt.show()
+    return fig
 

--- a/regressors/plots.py
+++ b/regressors/plots.py
@@ -47,24 +47,27 @@ def plot_residuals(clf, X, y, r_type='standardized', figsize=(10, 8)):
     """
     # Ensure we only plot residuals using classifiers we have tested
     assert isinstance(clf, supported_linear_models), (
-        "Classifiers of type {} not currently supported.".format(type(clf))
-    )
-    # With sns, only use their API so you don't change user stuff
-    sns.set_context("talk")  # Increase font size on plot
+        "Classifiers of type {} not currently supported.".format(type(clf)))
+    # Set plot style
     sns.set_style("whitegrid")
+    sns.set_context("talk")  # Increase font size on plot
     # Get residuals or standardized residuals
     resids = stats.residuals(clf, X, y, r_type)
     predictions = clf.predict(X)
     # Generate residual plot
     y_label = {'raw': 'Residuals', 'standardized': 'Standardized Residuals',
                'studentized': 'Studentized Residuals'}
-    fig = plt.figure('residuals', figsize=figsize)
-    plt.scatter(predictions, resids, s=14, c='gray', alpha=0.7)
-    plt.hlines(y=0, xmin=predictions.min() - 100, xmax=predictions.max() + 100,
-               linestyle='dotted')
-    plt.title("Residuals Plot")
-    plt.xlabel("Predictions")
-    plt.ylabel(y_label[r_type])
-    plt.show()
+    try:
+        fig = plt.figure('residuals', figsize=figsize)
+        plt.scatter(predictions, resids, s=14, c='gray', alpha=0.7)
+        plt.hlines(y=0, xmin=predictions.min(),
+                   xmax=predictions.max(), linestyle='dotted')
+        plt.title("Residuals Plot")
+        plt.xlabel("Predictions")
+        plt.ylabel(y_label[r_type])
+        plt.show()
+    except:
+        raise  # Re-raise the exception
+    finally:
+        sns.reset_orig()  # Always reset back to default matplotlib styles
     return fig
-

--- a/regressors/plots.py
+++ b/regressors/plots.py
@@ -8,12 +8,9 @@ from __future__ import unicode_literals
 
 import matplotlib.pyplot as plt
 import seaborn.apionly as sns
-from sklearn import linear_model as lm
 
 from regressors import stats
-
-supported_linear_models = (lm.LinearRegression, lm.Lasso, lm.Ridge,
-                           lm.ElasticNet)
+from regressors.regressors import supported_linear_models
 
 
 def plot_residuals(clf, X, y, r_type='standardized', figsize=(10, 10)):

--- a/regressors/regressors.py
+++ b/regressors/regressors.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 from sklearn import linear_model
 import numpy as np
 import pandas as pd
+from regressors import stats
 
 
 class LinearRegression(linear_model.LinearRegression):

--- a/regressors/regressors.py
+++ b/regressors/regressors.py
@@ -71,3 +71,10 @@ class LinearRegression(linear_model.LinearRegression):
         summary = {'coef': pd.Series(coeffs, index=labels)}
         df = pd.DataFrame(summary)
         return df
+
+
+def summary(clf, X_train, y_train):
+    sse = stats.sse(clf, X_train, y_train)
+
+    # Put into pandas data frame
+    return df

--- a/regressors/regressors.py
+++ b/regressors/regressors.py
@@ -5,13 +5,16 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from sklearn import linear_model
+from sklearn import linear_model as lm
 import numpy as np
 import pandas as pd
 from regressors import stats
 
+supported_linear_models = (lm.LinearRegression, lm.Lasso, lm.Ridge,
+                           lm.ElasticNet)
 
-class LinearRegression(linear_model.LinearRegression):
+
+class LinearRegression(lm.LinearRegression):
 
     def __init__(self, fit_intercept=True, normalize=False, copy_X=True,
                  n_jobs=1):

--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -6,39 +6,51 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from sklearn import linear_model as lm
-import seaborn.apionly as sns
 import numpy as np
-import matplotlib._pyplot as plt
-
-supported_linear_models = (lm.LinearRegression, lm.Lasso, lm.Ridge,
-                           lm.ElasticNet)
-# assert isinstance(clf, supported_linear_models), (
-#     "Classifiers of type {} not currently supported.".format(type(clf))
-# )
 
 
-def residuals(y_true, y_pred, standardized=True):
+def residuals(clf, X, y, r_type='standardized'):
+    """Calculate residuals or standardized residuals.
+
+    Parameters
+    ----------
+    clf : sklearn.linear_model
+        A scikit-learn linear model classifier with a `predict()` method.
+    X : numpy.ndarray
+        Training data used to fit the classifier.
+    y : numpy.ndarray
+        Target training values, of shape = [n_samples].
+    r_type : str
+        Type of residuals to return: ['raw', 'standardized', 'studentized'].
+        Defaults to 'standardized'.
+
+        * 'raw' will return the raw residuals.
+        * 'standardized' will return the standardized residuals, also known as
+          internally studentized residuals.
+        * 'studentized' will return the externally studentized residuals.
+
+    Returns
+    -------
+    numpy.ndarray
+        An array of residuals.
+    """
+    assert r_type in ('raw', 'standardized', 'studentized'), (
+        "Invalid option for 'r_type': {0}".format(r_type)
+    )
+    y_true = y.view(dtype='float')
+    # Use classifier to make predictions
+    y_pred = clf.predict(X)
     # Make sure dimensions agree (Numpy still allows subtraction if they don't)
     assert y_true.shape == y_pred.shape, (
         "Dimensions of y_true {0} do not match y_pred {1}".format(y_true.shape,
                                                                   y_pred.shape)
     )
-    # With sns, only use their API so you don't change user stuff
-    sns.set_context("talk")  # Increase font size on plot
-    # Get residuals or standardized residuals
-    resids = y_pred - y_true  # Residuals
-    if standardized is True:
-        resids = resids / np.std(resids)  # Standardize resids
-    fig = plt.figure(figsize=(10, 7))
-    sns.set_style("whitegrid")
-    plt.scatter(predictions, standardized_resids, s=14, c='gray',
-                alpha=0.7)
-    plt.hlines(y=0, xmin=predictions.min() - 100,
-               xmax=predictions.max() + 100,
-              linestyle='dotted')
-    plt.title("Residual Plot")
-    plt.xlabel("Predictions")
-    plt.ylabel("Standardized Residuals")
+    # Get raw residuals, or standardized or standardized residuals
+    resids = y_pred - y_true
+    if r_type == 'standardized':
+        resids = resids / np.std(resids)
+        # TODO (nikhil): make sure this corresponds to standardized residuals
+    # TODO (nikhil): calculate externally studentized residuals
+    return resids
 
 

--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -26,8 +26,11 @@ def residuals(clf, X, y, r_type='standardized'):
 
         * 'raw' will return the raw residuals.
         * 'standardized' will return the standardized residuals, also known as
-          internally studentized residuals.
-        * 'studentized' will return the externally studentized residuals.
+          internally studentized residuals, which is calculated as the residuals
+          divided by the square root of MSE (or the STD of the residuals).
+        * 'studentized' will return the externally studentized residuals, which
+          is calculated as the raw residuals divided by sqrt(LOO-MSE * (1 -
+          leverage_score)).
 
     Returns
     -------

--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""This module contains functions for calculating various statistics."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from sklearn import linear_model as lm
+import seaborn.apionly as sns
+import numpy as np
+import matplotlib._pyplot as plt
+
+supported_linear_models = (lm.LinearRegression, lm.Lasso, lm.Ridge,
+                           lm.ElasticNet)
+# assert isinstance(clf, supported_linear_models), (
+#     "Classifiers of type {} not currently supported.".format(type(clf))
+# )
+
+
+def residuals(y_true, y_pred, standardized=True):
+    # Make sure dimensions agree (Numpy still allows subtraction if they don't)
+    assert y_true.shape == y_pred.shape, (
+        "Dimensions of y_true {0} do not match y_pred {1}".format(y_true.shape,
+                                                                  y_pred.shape)
+    )
+    # With sns, only use their API so you don't change user stuff
+    sns.set_context("talk")  # Increase font size on plot
+    # Get residuals or standardized residuals
+    resids = y_pred - y_true  # Residuals
+    if standardized is True:
+        resids = resids / np.std(resids)  # Standardize resids
+    fig = plt.figure(figsize=(10, 7))
+    sns.set_style("whitegrid")
+    plt.scatter(predictions, standardized_resids, s=14, c='gray',
+                alpha=0.7)
+    plt.hlines(y=0, xmin=predictions.min() - 100,
+               xmax=predictions.max() + 100,
+              linestyle='dotted')
+    plt.title("Residual Plot")
+    plt.xlabel("Predictions")
+    plt.ylabel("Standardized Residuals")
+
+

--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -53,8 +53,24 @@ def residuals(clf, X, y, r_type='standardized'):
     resids = y_pred - y_true
     if r_type == 'standardized':
         resids = resids / np.std(resids)
-        # TODO (nikhil): make sure this corresponds to standardized residuals
-    # TODO (nikhil): calculate externally studentized residuals
+    if r_type == 'studentized':
+        # Prepare a blank array to hold studentized residuals
+        studentized_resids = np.zeros(y_true.shape[0], dtype='float')
+        # Calcluate hat matrix of X values so you can get leverage scores
+        hat_matrix = np.dot(
+            np.dot(X, np.linalg.inv(np.dot(np.transpose(X), X))),
+            np.transpose(X)
+        )
+        # For each point, calculate studentized residuals w/ leave-one-out MSE
+        for i in range(y_true.shape[0]):
+            # Make a mask so you can calculate leave-one-out MSE
+            mask = np.ones(y_true.shape[0], dtype='bool')
+            mask[i] = 0
+            loo_mse = np.average(resids[mask] ** 2, axis=0)  # Leave-one-out MSE
+            # Calculate studentized residuals
+            studentized_resids[i] = resids[i] / np.sqrt(
+                loo_mse * (1 - hat_matrix[i, i]))
+        resids = studentized_resids
     return resids
 
 

--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -53,7 +53,7 @@ def residuals(clf, X, y, r_type='standardized'):
     resids = y_pred - y_true
     if r_type == 'standardized':
         resids = resids / np.std(resids)
-    if r_type == 'studentized':
+    elif r_type == 'studentized':
         # Prepare a blank array to hold studentized residuals
         studentized_resids = np.zeros(y_true.shape[0], dtype='float')
         # Calcluate hat matrix of X values so you can get leverage scores

--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -34,6 +34,7 @@ def residuals(clf, X, y, r_type='standardized'):
     numpy.ndarray
         An array of residuals.
     """
+    # Make sure value of parameter 'r_type' is one we recognize
     assert r_type in ('raw', 'standardized', 'studentized'), (
         "Invalid option for 'r_type': {0}".format(r_type)
     )

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -14,6 +14,8 @@ from __future__ import unicode_literals
 
 import unittest2 as unittest
 from sklearn import datasets
+from sklearn import linear_model as lm
+from sklearn import naive_bayes
 import pandas as pd
 import numpy as np
 
@@ -110,6 +112,29 @@ class TestLinearRegression(unittest.TestCase):
         except Exception as e:
             self.fail("str(summary) raised "
                       "exception unexpectedly: {0}".format(e))
+
+
+class TestStats_Residuals(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_classifier_type_assertion(self):
+        # Test that assertion is raised for unsupported model
+        nb = naive_bayes.GaussianNB()
+        with self.assertRaises(AssertionError):
+            stats.residuals(nb, X, y)
+        # Test that assertion is not raise for supported models
+        for clf in stats.supported_linear_models:
+            try:
+                stats.residuals(clf(), X, y)
+            except Exception as e:
+                self.fail("Testing supported linear models in residuals "
+                          "function failed unexpectedly: {0}".format(e))
+
 
 if __name__ == '__main__':
     import sys

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -7,17 +7,16 @@ test_regressors
 
 Tests for the `regressors` module.
 """
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 
+import numpy as np
+import pandas as pd
 import unittest2 as unittest
 from sklearn import datasets
-from sklearn import linear_model as lm
-from sklearn import naive_bayes
-import pandas as pd
-import numpy as np
+from sklearn.decomposition import PCA
 
 from regressors import regressors
 from regressors import stats
@@ -114,7 +113,7 @@ class TestLinearRegression(unittest.TestCase):
                       "exception unexpectedly: {0}".format(e))
 
 
-class TestStats_Residuals(unittest.TestCase):
+class Test_Stats_Residuals(unittest.TestCase):
 
     def setUp(self):
         pass
@@ -122,19 +121,50 @@ class TestStats_Residuals(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_classifier_type_assertion(self):
+    def test_classifier_type_assertion_raised(self):
         # Test that assertion is raised for unsupported model
-        nb = naive_bayes.GaussianNB()
-        with self.assertRaises(AssertionError):
-            stats.residuals(nb, X, y)
+        pcomp = PCA()
+        pcomp.fit(X, y)
+        with self.assertRaises(AttributeError):
+            stats.residuals(pcomp, X, y)
+
+    def tests_classifier_type_assertion_not_raised(self):
         # Test that assertion is not raise for supported models
-        for clf in stats.supported_linear_models:
+        for classifier in regressors.supported_linear_models:
+            clf = classifier()
+            clf.fit(X, y)
             try:
-                stats.residuals(clf(), X, y)
+                stats.residuals(clf, X, y)
             except Exception as e:
                 self.fail("Testing supported linear models in residuals "
                           "function failed unexpectedly: {0}".format(e))
 
+    def test_getting_raw_residuals(self):
+        ols = regressors.LinearRegression()
+        ols.fit(X, y)
+        try:
+            stats.residuals(ols, X, y, r_type='raw')
+        except Exception as e:
+            self.fail("Testing raw residuals failed unexpectedly: "
+                      "{0}".format(e))
+
+    def test_getting_standardized_residuals(self):
+        ols = regressors.LinearRegression()
+        ols.fit(X, y)
+        try:
+            stats.residuals(ols, X, y, r_type='standardized')
+        except Exception as e:
+            self.fail("Testing standardized residuals failed unexpectedly: "
+                      "{0}".format(e))
+
+    def test_getting_studentized_residuals(self):
+        ols = regressors.LinearRegression()
+        ols.fit(X, y)
+        try:
+            stats.residuals(ols, X, y, r_type='studentized')
+        except Exception as e:
+            self.fail("Testing studentized residuals failed unexpectedly: "
+                      "{0}".format(e))
 
 if __name__ == '__main__':
     import sys

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -18,16 +18,19 @@ import pandas as pd
 import numpy as np
 
 from regressors import regressors
+from regressors import stats
+
+boston = datasets.load_boston()
+which_betas = np.ones(13, dtype=bool)
+which_betas[3] = False  # Eliminate dummy variable
+X = boston.data[:, which_betas]
+y = boston.target
 
 
 class TestLinearRegression(unittest.TestCase):
 
     def setUp(self):
-        boston = datasets.load_boston()
-        which_betas = np.ones(13, dtype=bool)
-        which_betas[3] = False  # Eliminate dummy variable
-        self.X = boston.data[:, which_betas]
-        self.y = boston.target
+        pass
 
     def tearDown(self):
         pass
@@ -35,71 +38,71 @@ class TestLinearRegression(unittest.TestCase):
     def test_LinearRegression_fit_with_no_xlabels(self):
         ols = regressors.LinearRegression()
         try:
-            ols.fit(self.X, self.y)
+            ols.fit(X, y)
         except Exception as e:
             self.fail("Fitting with no xlabels raised unexpected "
                       "exception: {0}".format(e))
 
     def test_LinearRegression_fit_with_xlabels_as_args(self):
         ols = regressors.LinearRegression()
-        labels = ['LABEL{0}'.format(i) for i in range(self.X.shape[1])]
+        labels = ['LABEL{0}'.format(i) for i in range(X.shape[1])]
         try:
-            ols.fit(self.X, self.y, labels)
+            ols.fit(X, y, labels)
         except Exception as e:
             self.fail("Fitting with xlabels as *args raised unexpected "
                       "exception: {0}".format(e))
 
     def test_LinearRegression_fit_with_xlabels_as_kwargs(self):
         ols = regressors.LinearRegression()
-        labels = ['LABEL{0}'.format(i) for i in range(self.X.shape[1])]
+        labels = ['LABEL{0}'.format(i) for i in range(X.shape[1])]
         try:
-            ols.fit(self.X, y=self.y, xlabels=labels)
+            ols.fit(X, y=y, xlabels=labels)
         except Exception as e:
             self.fail("Fitting with xlabels as **kwargs raised unexpected "
                       "exception: {0}".format(e))
 
     def test_LinearRegression_fit_with_xlabels_mixed_kwarg(self):
         ols = regressors.LinearRegression()
-        labels = ['LABEL{0}'.format(i) for i in range(self.X.shape[1])]
+        labels = ['LABEL{0}'.format(i) for i in range(X.shape[1])]
         try:
-            ols.fit(self.X, self.y, xlabels=labels)
+            ols.fit(X, y, xlabels=labels)
         except Exception as e:
             self.fail("Fitting with xlabels as **kwargs with y also as "
                       "**kwargs raised unexpected exception: {0}".format(e))
 
     def test_LinearRegression_fit_with_xlabels_all_kwargs(self):
         ols = regressors.LinearRegression()
-        labels = ['LABEL{0}'.format(i) for i in range(self.X.shape[1])]
+        labels = ['LABEL{0}'.format(i) for i in range(X.shape[1])]
         try:
-            ols.fit(X=self.X, y=self.y, xlabels=labels)
+            ols.fit(X=X, y=y, xlabels=labels)
         except Exception as e:
             self.fail("Fitting with xlabels with all parameters as "
                       "**kwargs raised unexpected exception: {0}".format(e))
 
     def test_LinearRegression_fit_with_xlabels_out_of_position_kwargs(self):
         ols = regressors.LinearRegression()
-        labels = ['LABEL{0}'.format(i) for i in range(self.X.shape[1])]
+        labels = ['LABEL{0}'.format(i) for i in range(X.shape[1])]
         try:
-            ols.fit(X=self.X, xlabels=labels, y=self.y)
+            ols.fit(X=X, xlabels=labels, y=y)
         except Exception as e:
             self.fail("Fitting with xlabels with all parameters as "
                       "**kwargs raised unexpected exception: {0}".format(e))
 
     def test_LinearRegression_fit_with_xlabels_args_out_of_pos_args_fails(self):
         ols = regressors.LinearRegression()
-        labels = ['LABEL{0}'.format(i) for i in range(self.X.shape[1])]
+        labels = ['LABEL{0}'.format(i) for i in range(X.shape[1])]
         with self.assertRaises(AssertionError):
-            ols.fit(self.X, labels, self.y)
+            ols.fit(X, labels, y)
 
     def test_LinearRegression_xlabel_dimensions_error_checking(self):
         ols = regressors.LinearRegression()
         with self.assertRaises(AssertionError):
-            ols.fit(self.X, self.y, xlabels=['LABEL1', 'LABEL2'])
+            ols.fit(X, y, xlabels=['LABEL1', 'LABEL2'])
 
     def test_LinearRegression_summary(self):
         ols = regressors.LinearRegression()
-        labels = ['LABEL{0}'.format(i) for i in range(self.X.shape[1])]
-        ols.fit(self.X, self.y, labels)
+        labels = ['LABEL{0}'.format(i) for i in range(X.shape[1])]
+        ols.fit(X, y, labels)
         summary = ols.summary()
         self.assertIsInstance(summary, pd.core.frame.DataFrame)
         try:


### PR DESCRIPTION
This PR:

* Implements a `residuals()` function for calculating raw, standardized, or studentized residuals.
* Implements a `plot_residuals()` function for plotting raw, standardized, or studentized residuals (calculated using the `residuals()` function.
* Adds some tests for testing the `residuals()` function. Plotting functions can't be tested very well with matplotlib, and especially with matplotlib in a virtualenv: see http://matplotlib.org/1.5.0/faq/virtualenv_faq.html. `plot_residuals()` was verified by hand.