### PR TITLE
Removed use_2to3 argument in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     test_suite='tests',
-    tests_require=test_requirements,
-    use_2to3=True
+    tests_require=test_requirements
 )


### PR DESCRIPTION
This should fix #24 as the use_2to3 argument is no longer supported in setup.py per distutils.