### PR TITLE
Bug Repair: Syntax Errors

### DIFF
--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -47,7 +47,7 @@ def residuals(clf, X, y, r_type='standardized'):
     # Make sure value of parameter 'r_type' is one we recognize
     assert r_type in ('raw', 'standardized', 'studentized'), (
         "Invalid option for 'r_type': {0}".format(r_type))
-    y_true = y.view(dtype='float')
+    y_true = y.astype(np.float32).copy()
     # Use classifier to make predictions
     y_pred = clf.predict(X)
     # Make sure dimensions agree (Numpy still allows subtraction if they don't)

--- a/regressors/stats.py
+++ b/regressors/stats.py
@@ -251,7 +251,7 @@ def summary(clf, X, y, xlabels=None):
     )
     try:
         coef_df['Estimate'] = np.concatenate(
-            (np.round(np.array([clf.intercept_]), 6), np.round((clf.coef_), 6))
+            (np.round(np.array([clf.intercept_]), 6), np.round((clf.coef_), 6)))
     except Exception as e:
         coef_df['Estimate'] = np.concatenate(
             (
@@ -282,5 +282,3 @@ def summary(clf, X, y, xlabels=None):
         metrics.r2_score(y, clf.predict(X)), adj_r2_score(clf, X, y)))
     print('F-statistic: {0:.2f} on {1} features'.format(
         f_stat(clf, X, y), ncols))
-
-


### PR DESCRIPTION
- `coef_df['Estimate'] = np.concatenate((np.round(np.array([clf.intercept_]), 6), np.round((clf.coef_), 6)))` was missing a parenthesis. 

- `.view()` is traditionally used to "create a new array object that looks at the same memory as the original array, but with a different data type or shape." However, if `y` is not a float array, `.view()` doesn't actually convert the data but creates a view that interprets the same memory as floats, which led to unexpected results for me. Specifically, the `summary()` function would have an assertion error because `y_pred` had a different shape from `y_true`

I did not add any new tests because existing tests should cover everything. Some of the flake tests failed due to my device being an ARM device, but I did manual testing. 

@nsh87 @nhaas-twist 